### PR TITLE
Test expansion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           key: php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup php
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, soap, intl, exif, iconv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,4 +35,4 @@ jobs:
         run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
-        run: ./vendor/bin/pest
+        run: php --version && ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,4 +35,4 @@ jobs:
         run: composer install --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
-        run: php --version && ./vendor/bin/pest
+        run: php --version && ./vendor/bin/pest --version && ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+        run: composer install --no-interaction --no-suggest
 
       - name: Execute tests
         run: php --version && ./vendor/bin/pest --version && ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+        run: composer install --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         run: php --version && ./vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,6 @@
       "JustSteveKing\\UriBuilder\\": "src/"
     }
   },
-  "autoload-dev": {
-    "psr-4": {
-      "JustSteveKing\\UriBuilder\\Tests\\": "src/"
-    }
-  },
   "require": {
     "php": "^8.0",
     "juststeveking/parameterbag": "^2.0"

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -55,7 +55,10 @@ final class Uri
 
         $uri = parse_url($uri);
 
-        if (! is_array($uri)) {
+        if (
+            ! is_array($uri)
+            || ! isset($uri['scheme'], $uri['host'])
+        ) {
             throw new InvalidArgumentException(
                 message: "URI failed to parse using parse_url, please ensure is valid URL. Passed in [$uri]",
             );

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -50,3 +50,8 @@ function build(): Uri
 {
     return Uri::build();
 }
+
+function random_string(): string
+{
+    return sha1(random_bytes(11));
+}

--- a/tests/UriBuilderTest.php
+++ b/tests/UriBuilderTest.php
@@ -1,18 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 use JustSteveKing\UriBuilder\Uri;
 
 use function PHPUnit\Framework\assertEquals;
-
-it('can create a new instance of the URI builder', function () {
-    $object = Uri::build();
-
-    expect(
-        value: $object,
-    )->toBeInstanceOf(
-        class: Uri::class,
-    );
-});
 
 it('will create a new URI Builder from a string', function () {
     $object = Uri::fromString(

--- a/tests/UriBuilderTest.php
+++ b/tests/UriBuilderTest.php
@@ -318,7 +318,7 @@ it('cannot set the port with no value', function () {
 );
 
 it('cannot set the port explicitly to null', function () {
-    Uri::build()->addPort();
+    Uri::build()->addPort(port: null);
 })->throws(
     exceptionClass: InvalidArgumentException::class,
 );


### PR DESCRIPTION
This PR expands the test suites to cover more cases without changing the main class.

- removed the build test as it was testing what the code was explicitly returning via return type lock - this means the test was superfluous.
- added datasets where we could test repeatedly with multiple datasets.
- cleaned up a few expectations where they were loose-equals checking null against ''
- added few more explicit tests
- where it's testing for exception throws, it won't execute a secondary check. These have been promoted to their own tests.
- added 1 change to URI to reduce final psalm note.

### notes
While this is not my Coding Style, I've tried to keep to the style in the file as much as possible, though a few slip ups may have snuck through
